### PR TITLE
✨ Support native ad type for Zucks ad network

### DIFF
--- a/ads/zucks.js
+++ b/ads/zucks.js
@@ -22,5 +22,12 @@ import {validateData, writeScript} from '../3p/3p';
  */
 export function zucks(global, data) {
   validateData(data, ['frameId']);
-  writeScript(global, `https://j.zucks.net.zimg.jp/j?f=${data['frameId']}`);
+
+  let script = `https://j.zucks.net.zimg.jp/j?f=${data['frameId']}`;
+
+  if (data['adtype'] === 'native') {
+    script = `https://j.zucks.net.zimg.jp/n?f=${data['frameId']}`;
+  }
+
+  writeScript(global, script);
 }


### PR DESCRIPTION
We currently support another new type of ad and would like to integrate with `amp-ad`.
This is a non breaking changes since the previous api won't change.

Previous api

```html
  <amp-ad width="320" height="50"
      type="zucks"
      data-frame-id="_bda46cf5ac">
  </amp-ad>
```

[Example](https://github.com/ampproject/amphtml/blob/master/examples/ads.amp.html#L1670-L1674) in documentation will work as before. To use native ad for amp tag, `data-frame-adtype` have to be set to `native`

```html
  <amp-ad width="360" height="110"
      type="zucks"
      data-adtype="native"
      data-frame-id="_d605022eb9">
  </amp-ad>
```