### PR TITLE
add new tagtype for fluct

### DIFF
--- a/ads/_config.js
+++ b/ads/_config.js
@@ -512,9 +512,12 @@ const adConfig = jsonConfiguration({
   'flite': {},
 
   'fluct': {
+    prefetch: [
+      'https://pdn.adingo.jp/p.js',
+    ],
     preconnect: [
       'https://cdn-fluct.sh.adingo.jp',
-      'https://s.sh.adingo.jp',
+      'https://sh.adingo.jp',
       'https://i.adingo.jp',
     ],
   },

--- a/ads/vendors/fluct.js
+++ b/ads/vendors/fluct.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {validateData, writeScript} from '../../3p/3p';
+import {validateData, writeScript, loadScript} from '../../3p/3p';
 
 /* global adingoFluct: false */
 
@@ -24,11 +24,26 @@ import {validateData, writeScript} from '../../3p/3p';
  */
 export function fluct(global, data) {
   validateData(data, ['g', 'u']);
-  writeScript(
-    global,
-    `https://cdn-fluct.sh.adingo.jp/f.js?G=${encodeURIComponent(data['g'])}`,
-    function () {
-      adingoFluct.showAd(data['u']);
-    }
-  );
+
+  if (data['tagtype'] === 'api') {
+    const cls = `fluct-unit-${data['u']}`;
+    const d = global.document.createElement('div');
+    d.setAttribute('class', cls);
+    global.document.getElementById('c').appendChild(d);
+
+    loadScript(global, "https://pdn.adingo.jp/p.js", function() {
+      fluctAdScript.cmd.push(function (cmd) {
+        cmd.loadByGroup(data['g']);
+        cmd.display(`.${cls}`, data['u']);
+      });
+    });
+  } else {
+    writeScript(
+      global,
+      `https://cdn-fluct.sh.adingo.jp/f.js?G=${encodeURIComponent(data['g'])}`,
+      function () {
+        adingoFluct.showAd(data['u']);
+      }
+    );
+  }
 }

--- a/ads/vendors/fluct.md
+++ b/ads/vendors/fluct.md
@@ -25,6 +25,7 @@ limitations under the License.
   type="fluct"
   data-g="{GROUP-ID}"
   data-u="{UNIT-ID}"
+  data-tagtype="api"
 >
 </amp-ad>
 ```

--- a/examples/amp-ad/ads.amp.html
+++ b/examples/amp-ad/ads.amp.html
@@ -1281,6 +1281,13 @@
       data-u="1000101409">
   </amp-ad>
 
+  <amp-ad width="300" height="250"
+          type="fluct"
+          data-g="1000128429"
+          data-u="1000220560"
+          data-tagtype="api">
+  </amp-ad>
+
   <h2>Fork Media</h2>
   <amp-ad width="50" height="66"
       type="forkmedia"


### PR DESCRIPTION
* 本体に出す前に一旦内部レビュー
* why
  * fluctのp.jsをamp対応（ampタグで媒体に納品する際に旧テンプレートでの発行をやめたい）
* what
  * 既存のタグはそのまま、p.jsとそれ以外を分岐するdata-typeを追加した
  